### PR TITLE
Transpile chameleon-sdk dep chmjs/chameleon-runner-android#6

### DIFF
--- a/generator/templates/default/babel.config.js
+++ b/generator/templates/default/babel.config.js
@@ -1,4 +1,7 @@
 module.exports = {
+  plugins: [
+    'lodash',
+  ],
   presets: [
     '@vue/app',
   ],

--- a/generator/templates/default/package.json
+++ b/generator/templates/default/package.json
@@ -44,14 +44,6 @@
   "chameleon": {
     "bundle": "{{ bundleName }}"
   },
-  "babel": {
-    "plugins": [
-      "lodash"
-    ],
-    "presets": [
-      "@vue/app"
-    ]
-  },
   "jest": {
     "moduleNameMapper": {
       "@/(.*)$": "<rootDir>/src/$1"

--- a/generator/templates/default/vue.config.js
+++ b/generator/templates/default/vue.config.js
@@ -9,6 +9,9 @@ const globalSuffix = isMeta ? '_META' : '';
 
 module.exports = {
   lintOnSave: true,
+  transpileDependencies: [
+    '@nsoft/chameleon-sdk',
+  ],
   chainWebpack: (wConfig) => {
     wConfig
       .when(process.env.NODE_ENV === 'production', (config) => {


### PR DESCRIPTION
In order to support older browsers (like android =< 5 native browser) we need to transpile `chameleon-sdk` dep. This solution [needs babel config](https://github.com/vuejs/vue-cli/issues/1552#issuecomment-396674224) to be declared in separate config file.

Bundles made with this template have already been updated.