### PR TITLE
Sample style

### DIFF
--- a/generator/index.js
+++ b/generator/index.js
@@ -23,6 +23,7 @@ module.exports = (api, opts, rootOpts) => {
       '@vue/test-utils': '^1.0.0-beta.24',
       axios: '^0.18.0',
       'babel-core': '^7.0.0-bridge.0',
+      'babel-plugin-lodash': "^3.3.2",
       eslint: '^5.5.0',
       'eslint-config-airbnb-base': '^13.1.0',
       'eslint-import-resolver-webpack': '^0.10.1',

--- a/generator/templates/default/build/bundle.js
+++ b/generator/templates/default/build/bundle.js
@@ -11,7 +11,9 @@ zip.file('manifest.json', fs.readFileSync('./build/manifest.json'));
 
 if (manifest.styles) {
   each(manifest.styles, (style) => {
-    zip.file(style, fs.readFileSync(resolveDist(style)));
+    if (fs.existsSync(resolveDist(style))) {
+      zip.file(style, fs.readFileSync(resolveDist(style)));
+    }
   });
 }
 

--- a/generator/templates/default/build/cleanup.js
+++ b/generator/templates/default/build/cleanup.js
@@ -5,7 +5,7 @@ const { each } = require('lodash');
 const files = fs.readdirSync(path.join(__dirname, '../dist'));
 each(files, (file) => {
   if (file.indexOf('common') >= 0) {
-    fs.unlink(path.join(__dirname, '../dist', file), () => {});
+    fs.unlink(path.join(__dirname, '../dist', file), () => { });
     return;
   }
 
@@ -18,13 +18,11 @@ each(files, (file) => {
   const minIndex = nameParts.indexOf('min');
   const isCss = nameParts.indexOf('css') >= 0;
   if (minIndex < 0 && !isCss) {
-    fs.unlink(path.join(__dirname, '../dist', file), () => {});
+    fs.unlink(path.join(__dirname, '../dist', file), () => {  });
     return;
   }
 
-  if (isCss) {
-    nameParts.splice(0, 1, 'index');
-  } else {
+  if (!isCss) {
     nameParts.splice(minIndex, 1);
   }
 

--- a/generator/templates/default/build/cleanup.js
+++ b/generator/templates/default/build/cleanup.js
@@ -18,7 +18,7 @@ each(files, (file) => {
   const minIndex = nameParts.indexOf('min');
   const isCss = nameParts.indexOf('css') >= 0;
   if (minIndex < 0 && !isCss) {
-    fs.unlink(path.join(__dirname, '../dist', file), () => {  });
+    fs.unlink(path.join(__dirname, '../dist', file), () => { });
     return;
   }
 

--- a/generator/templates/default/build/manifest.json
+++ b/generator/templates/default/build/manifest.json
@@ -3,7 +3,7 @@
   "namespace": "<%= bundleNamespace %>-",
   "version": 1,
   "styles": [
-    "index.css"
+    "bundle.css"
   ],
   "scripts": [
     {

--- a/generator/templates/default/src/index.js
+++ b/generator/templates/default/src/index.js
@@ -1,4 +1,5 @@
 import * as components from './components';
+require('./style/main.styl');
 
 export default {
   install(Vue, options) {

--- a/generator/templates/default/src/style/main.styl
+++ b/generator/templates/default/src/style/main.styl
@@ -1,0 +1,4 @@
+html,
+body
+  padding: 0
+  margin: 0


### PR DESCRIPTION
 - Running bundle script would throw error when there was no any css files, that's why I've added: 
_fs.existsSync(resolveDist(style))_ condition
- There was no main css style script
- Added mssing babel-plugin-lodash devDep
- Renamed index.css to bundle, to make in consistent with other bundle files.