### PR TITLE
refactored bundle name and namespace validation to avoid duplication …

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Vue CLI plugin for Chameleon bundles
 This is a project template created from [vue-cli 3.0](https://github.com/vuejs/vue-cli). We strongly recommend to use it with Vue CLI stable version, i.e. 3.0.0 and above, due to build inconsistencies in lower versions.
 
 ``` bask
-$ npm install -g @vue/cli                # Install vue/cli if you haven't already
-$ vue create my-project                  # Create a new project
-$ cd my-project                          # Navigate into your new project folder
-$ vue add @nsoft/chameleon-bundle        # Add & invoke this plugin to apply bundle template
-$ npm run serve                          # Run app and open it in your browser
+$ npm install -g @vue/cli                           # Install vue/cli if you haven't already
+$ vue create my-project                             # Create a new project
+$ cd my-project                                     # Navigate into your new project folder
+$ vue add @nsoft/chameleon-bundle ${authToken}      # Add & invoke this plugin to apply bundle template
+$ npm run serve                                     # Run app and open it in your browser
 ```
 
 **Options**

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
   "bugs": {
     "url": "https://github.com/nsftx/vue-cli-plugin-chameleon-bundle/issues"
   },
-  "homepage": "https://github.com/nsftx/vue-cli-plugin-chameleon-bundle#readme"
+  "homepage": "https://github.com/nsftx/vue-cli-plugin-chameleon-bundle#readme",
+  "dependencies": {
+    "axios": "^0.19.0"
+  }
 }

--- a/prompts.js
+++ b/prompts.js
@@ -10,18 +10,17 @@ const http = axios.create({
 const validateBundleName = (name) => {
   if (name.length < 2) {
     return 'Bundle name must contain two or more characters';
-  } else {
-    return http.get('/bundles', {
-      params: {
-        name: name,
-      },
-    }).then((response) => {
-      if (response.data.length > 0) {
-        return `Bundle name already exist, try with a different name!`;
-      }
-      return true;
-    });
   }
+  return http.get('/bundles', {
+    params: {
+      name: name,
+    },
+  }).then((response) => {
+    if (response.data.length > 0) {
+      return `Bundle name already exist, try with a different name!`;
+    }
+    return true;
+  });
 };
 
 const validateBundleNamespace = (namespace) => {
@@ -32,18 +31,17 @@ const validateBundleNamespace = (namespace) => {
   if (!isValid) {
     return `Bundle namespace must contain at least one and maximum of 2 characters.
     Special characters and numbers are not allowed.`;
-  } else {
-    return http.get('/bundles', {
-      params: {
-        name: paramsName,
-      },
-    }).then((response) => {
-      if (response.data.length > 0) {
-        return `Bundle namespace already exist, try with a different namespace!`;
-      }
-      return true;
-    });
   }
+  return http.get('/bundles', {
+    params: {
+      name: paramsName,
+    },
+  }).then((response) => {
+    if (response.data.length > 0) {
+      return `Bundle namespace already exist, try with a different namespace!`;
+    }
+    return true;
+  });
 };
 
 module.exports = [

--- a/prompts.js
+++ b/prompts.js
@@ -1,20 +1,49 @@
+const axios = require('axios');
+
+const http = axios.create({
+  headers: {
+    Authorization: `Bearer ${process.argv[4]}`,
+  },
+  baseURL: 'https://api.staging-chameleon.nsoft.cloud',
+});
+
 const validateBundleName = (name) => {
   if (name.length < 2) {
     return 'Bundle name must contain two or more characters';
+  } else {
+    return http.get('/bundles', {
+      params: {
+        name: name,
+      },
+    }).then((response) => {
+      if (response.data.length > 0) {
+        return `Bundle name already exist, try with a different name!`;
+      }
+      return true;
+    });
   }
-  return true;
 };
 
 const validateBundleNamespace = (namespace) => {
+  const paramsName = `${namespace}-`;
   const pattern = /^[a-z]{1,2}$/;
   const isValid = pattern.test(namespace);
 
   if (!isValid) {
     return `Bundle namespace must contain at least one and maximum of 2 characters.
-    Special characters are not allowed.`;
+    Special characters and numbers are not allowed.`;
+  } else {
+    return http.get('/bundles', {
+      params: {
+        name: paramsName,
+      },
+    }).then((response) => {
+      if (response.data.length > 0) {
+        return `Bundle namespace already exist, try with a different namespace!`;
+      }
+      return true;
+    });
   }
-
-  return true;
 };
 
 module.exports = [


### PR DESCRIPTION
refactored bundle name and namespace validation to avoid duplication and refactored  'vue add @nsoft/chameleon-bundle' command  so you have to forward token now => 'vue add @nsoft/chameleon-bundle ${authToken}'

Resolves #8 